### PR TITLE
[refactor] 블로그 포스트 등록 폼에 react hook form 적용

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "match-sorter": "^6.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.53.0",
     "react-icons": "^5.0.1",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.15.0",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@egjs/react-flicking':
     specifier: ^4.11.2
@@ -38,6 +34,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.53.0
+    version: 7.53.0(react@18.2.0)
   react-icons:
     specifier: ^5.0.1
     version: 5.0.1(react@18.2.0)
@@ -3492,6 +3491,15 @@ packages:
       scheduler: 0.23.0
     dev: false
 
+  /react-hook-form@7.53.0(react@18.2.0):
+    resolution: {integrity: sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-icons@5.0.1(react@18.2.0):
     resolution: {integrity: sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==}
     peerDependencies:
@@ -4112,3 +4120,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/front/src/components/markdownEditor/index.tsx
+++ b/front/src/components/markdownEditor/index.tsx
@@ -1,5 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
-
+import { ChangeHandler } from "react-hook-form";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 
@@ -10,8 +9,8 @@ interface MDEditorProps {
   height?: number;
   pWidth?: number;
   pHeight?: number;
-  value: string;
-  setValue: Dispatch<SetStateAction<string>>;
+  onChange: ChangeHandler;
+  name: string;
 }
 
 export const MDEditor = ({
@@ -19,8 +18,8 @@ export const MDEditor = ({
   height,
   pWidth,
   pHeight,
-  value,
-  setValue,
+  onChange,
+  name,
 }: MDEditorProps) => {
   const modules = {
     toolbar: [
@@ -56,6 +55,16 @@ export const MDEditor = ({
     "background",
   ];
 
+  // 참고한 블로그 글: https://velog.io/@soorokim/react-hook-form-react-quill-%EB%AF%B8%EC%84%B8%ED%8C%81-%EC%97%B0%EB%8F%99%ED%95%98%EA%B8%B0
+  const handleOnChange = (
+    value: string
+    // d: any,
+    // s: any,
+    // editor: ReactQuill.UnprivilegedEditor
+  ) => {
+    onChange({ target: { name, value } });
+  };
+
   return (
     <MDEditorWrapper
       width={width}
@@ -65,8 +74,7 @@ export const MDEditor = ({
     >
       <ReactQuill
         theme="snow"
-        value={value}
-        onChange={setValue}
+        onChange={handleOnChange}
         modules={modules}
         formats={formats}
         style={{ height: "calc(100% - 2.5rem - 2px" }}

--- a/front/src/features/blog/api/usePostPost.ts
+++ b/front/src/features/blog/api/usePostPost.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { QUERY_KEY } from "@apis/queryKeys";
 
-type PostPostReq = {
+export type PostPostReq = {
   title: string; // 제목 (null, 빈 문자열 불가능)
   subtitle: string; // 부제 (null 가능)
   description: string; // 한줄요약 (null 가능)

--- a/front/src/features/blog/pages/postRegister/index.tsx
+++ b/front/src/features/blog/pages/postRegister/index.tsx
@@ -22,7 +22,12 @@ export const PostRegister = () => {
   const selectedCategoryId = useAtomValue(selectedCategoryIdAtom);
   const isEditingCategoryName = useAtomValue(isEditingCategoryNameAtom);
   const navigate = useNavigate();
-  const { register, handleSubmit } = useForm<PostPostReq>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<PostPostReq>({
     mode: "onChange",
   });
   const { mutateAsync } = usePostPost();
@@ -48,20 +53,54 @@ export const PostRegister = () => {
               required: true,
               validate: (v) => v.trim().length !== 0,
               maxLength: 50,
+              onChange: (e) => {
+                const value = e.target.value;
+                if (value.length > 50) {
+                  setValue("title", value.substring(0, 50));
+                }
+              },
             })}
+            aria-invalid={errors.title ? "true" : "false"}
+            placeholder="제목(최대 50자)"
           />
         </FlexDiv>
         <FlexDiv $pWidth={100}>
           <Text $bold={true}>부제목</Text>
-          <PostRegisterInput {...register("subtitle", { maxLength: 50 })} />
+          <PostRegisterInput
+            {...register("subtitle", {
+              maxLength: 50,
+              onChange: (e) => {
+                const value = e.target.value;
+                if (value.length > 50) {
+                  setValue("subtitle", value.substring(0, 50));
+                }
+              },
+            })}
+            aria-invalid={errors.subtitle ? "true" : "false"}
+            placeholder="부제목(최대 50자)"
+          />
         </FlexDiv>
         <FlexDiv $pWidth={100}>
           <Text $bold={true}>한줄요약</Text>
-          <PostRegisterInput {...register("description", { maxLength: 200 })} />
+          <PostRegisterInput
+            {...register("description", { maxLength: 200 })}
+            aria-invalid={errors.description ? "true" : "false"}
+            placeholder="한줄요약(최대 200자)"
+          />
         </FlexDiv>
-        <Text $bold={true}>본문</Text>
-        {/* TODO: content 길이 validation */}
-        <MDEditor {...register("content", { required: true })} />
+        <FlexDiv $pWidth={100} $justify="space-between">
+          <Text $bold={true}>본문</Text>
+          {errors.title?.type === "required" && <p>제목을 입력해주세요.</p>}
+          {errors.description?.type === "maxLength" && (
+            <p>한줄요약은 최대 200자까지 가능합니다.</p>
+          )}
+          {errors.content?.type === "required" && <p>내용을 입력해주세요.</p>}
+        </FlexDiv>
+        {/* TODO: content 공백 입력 제한 validation */}
+        <MDEditor
+          {...register("content", { required: true })}
+          aria-invalid={errors.content ? "true" : "false"}
+        />
       </FlexDiv>
       <FlexDiv
         direction="column"


### PR DESCRIPTION
### FEAT
- 블로그 포스트 등록 폼에 react-hook-form 적용

### TODO
- content(내용) 공백(스페이스 또는 엔터)에 대한 validation 처리