### PR TITLE
chore: cd test2 - PATH 변수 출력

### DIFF
--- a/.github/workflows/deploy-fe.yml
+++ b/.github/workflows/deploy-fe.yml
@@ -23,7 +23,9 @@ jobs:
           cache: "pnpm" # pnpm 캐시 설정
 
       - name: Install pnpm
-        run: npm install -g pnpm # pnpm 설치
+        run: |
+          npm install -g pnpm # pnpm 설치
+          echo $PATH # PATH 환경 변수 출력
 
       - name: Install dependencies
         run: pnpm install # 의존성 설치


### PR DESCRIPTION
github actions 동작중 에러 발생에 따라 pnpm 설치 경로를 알기 위해 PATH 변수 출력문 추가

deploy
Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
